### PR TITLE
Add shebang to index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'fs-extra';
 import path from 'path';
 


### PR DESCRIPTION
Hi.
I really liked your script, but I had problem to use it as command line tool after installing it globally:
`npm install -g npm-link-copy`

After running
`npm-link-copy <some directory>`

I had following error:
```
npm-link-copy: line 1: use strict: command not found
```

I turned out bash by default does not know how to interpret `.js` script.
Adding shebang in index.js fixed issue for me.

Thanks in advance and have a great day.